### PR TITLE
[LIVY-582][TESTS] Hostname in python-api test should be lower case to…

### DIFF
--- a/python-api/src/test/python/livy-tests/client_test.py
+++ b/python-api/src/test/python/livy-tests/client_test.py
@@ -26,7 +26,8 @@ from livy.client import HttpClient
 
 session_id = 0
 job_id = 1
-base_uri = 'http://{0}:{1}'.format(socket.gethostname(), 8998)
+# Make sure host name is lower case. See LIVY-582
+base_uri = 'http://{0}:{1}'.format(socket.gethostname().lower(), 8998)
 client_test = None
 invoked_queued_callback = False
 invoked_running_callback = False


### PR DESCRIPTION
… avoid test failures

## What changes were proposed in this pull request?
In the python-API test code, when returning a mocked response, the mock lib will compare the URL with the predefined URLs case sensitive. However, the `Request` lib used in the Livy python API will change the URL to lower case. This will cause test failures on a machine with an upper case hostname.

This patch turns the hostname in python-API test code into the lower case to avoid such test failures.

## How was this patch tested?
Existing test. Run test specifically on a machine with an upper case hostname.

Author: Yiheng Wang <yihengw@gmail.com>

Closes #180 from yiheng/fix_582.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)
(Include a link to the associated JIRA and make sure to add a link to this pr on the JIRA as well)

## How was this patch tested?

(Please explain how this patch was tested. E.g. unit tests, integration tests, manual tests)
(If this patch involves UI changes, please attach a screenshot; otherwise, remove this)

Please review https://livy.incubator.apache.org/community/ before opening a pull request.
